### PR TITLE
update to have year desc order

### DIFF
--- a/source/ngComboDatePicker.js
+++ b/source/ngComboDatePicker.js
@@ -21,7 +21,8 @@ angular.module("ngComboDatePicker", [])
             ngOrder: '@',
             ngAttrsDate: '@',
             ngAttrsMonth: '@',
-            ngAttrsYear: '@' 
+            ngAttrsYear: '@',
+						ngYearOrder: '@'
         },
         controller: ['$scope', function($scope) {
             // Define function for parse dates.
@@ -99,10 +100,17 @@ angular.module("ngComboDatePicker", [])
             if($scope.ngModel > $scope.maxDate) $scope.ngModel = $scope.maxDate;
 
             // Initialize list of years.
+						$scope.ngYearOrder = $scope.ngYearOrder ? $scope.ngYearOrder : "asc"; //set default order value
             $scope.years = [];
-            for(var i=$scope.minDate.getFullYear(); i<=$scope.maxDate.getFullYear(); i++) {
-                $scope.years.push(i);
-            }
+						if($scope.ngYearOrder == "desc") {
+							for(var i=$scope.maxDate.getFullYear(); i>=$scope.minDate.getFullYear(); i--) {
+									$scope.years.push(i);
+							}
+						} else {//"asc" order by default
+							for(var i=$scope.minDate.getFullYear(); i<=$scope.maxDate.getFullYear(); i++) {
+									$scope.years.push(i);
+							}
+						}
 
             // Initialize list of months names.
             var monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];


### PR DESCRIPTION
defaults at "asc" order but can use "desc" like so:
ng-year-order="desc"

Note: needs min.js created from whatever process you using
###### 

this is a nice add-on I think ... we have many old users for our pharma questionnaire so we start at 1900 but for most users its hard to scroll to the average date of 1960/1970... so this allows year to go in desc order for usability purposes
